### PR TITLE
Issue 2 setup ci/cd for reference models

### DIFF
--- a/.github/workflows/CI_manual.yml
+++ b/.github/workflows/CI_manual.yml
@@ -1,0 +1,37 @@
+
+name: CI on manual trigger
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v10
+
+      - name: Install clang and runtime dependencies
+        run: |
+          sudo apt install clang libunwind-dev
+          sudo apt install libgc-dev libre2-dev
+
+      - name: Checkout cli repo
+        uses: actions/checkout@v2
+        with:
+          repository: nervosum/nervosum
+          path: cli
+
+      - name: Build the CLI binary
+        run: |
+          cd cli
+          sbt cli/nativeLink
+
+      - name: Run CLI
+        run: cli/cli/target/scala-2.11/cli-out build
+
+
+
+
+

--- a/.github/workflows/CI_manual.yml
+++ b/.github/workflows/CI_manual.yml
@@ -13,9 +13,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
 
       - name: Install clang and runtime dependencies
-        run: |
-          sudo apt install clang libunwind-dev
-          sudo apt install libgc-dev libre2-dev
+        run: sudo apt install clang libunwind-dev libgc-dev libre2-dev
 
       - name: Checkout cli repo
         uses: actions/checkout@v2
@@ -30,8 +28,3 @@ jobs:
 
       - name: Run CLI
         run: cli/cli/target/scala-2.11/cli-out build
-
-
-
-
-

--- a/.github/workflows/CI_on_push.yml
+++ b/.github/workflows/CI_on_push.yml
@@ -1,12 +1,10 @@
 
-name: CI on push to main or issue-2 branch
+name: CI on push to main
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
-      - issue-2-Setup_CI/CD_for_reference-models
 
 jobs:
   build:
@@ -17,9 +15,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
 
       - name: Install clang and runtime dependencies
-        run: |
-          sudo apt install clang libunwind-dev
-          sudo apt install libgc-dev libre2-dev
+        run: sudo apt install clang libunwind-dev libgc-dev libre2-dev
 
       - name: Checkout cli repo
         uses: actions/checkout@v2
@@ -34,8 +30,3 @@ jobs:
 
       - name: Run CLI
         run: cli/cli/target/scala-2.11/cli-out build
-
-
-
-
-

--- a/.github/workflows/CI_on_push.yml
+++ b/.github/workflows/CI_on_push.yml
@@ -1,0 +1,41 @@
+
+name: CI on push to main or issue-2 branch
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - issue-2-Setup_CI/CD_for_reference-models
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v10
+
+      - name: Install clang and runtime dependencies
+        run: |
+          sudo apt install clang libunwind-dev
+          sudo apt install libgc-dev libre2-dev
+
+      - name: Checkout cli repo
+        uses: actions/checkout@v2
+        with:
+          repository: nervosum/nervosum
+          path: cli
+
+      - name: Build the CLI binary
+        run: |
+          cd cli
+          sbt cli/nativeLink
+
+      - name: Run CLI
+        run: cli/cli/target/scala-2.11/cli-out build
+
+
+
+
+


### PR DESCRIPTION
addresses issue #2 Setup CI/CD for reference-models 

Sets up CI by means of Github Actions

**Workflow file - CI_on_push.yml** 

Triggers CI on push to main (and the issue-2 branch for testing purposes currently)
- it sets up Scala incl Scala native
- mounts the master branche of the CLI 
- builds the CLI binary 
- runs the CLI and its corresponding 'build' command

**Workflow file - CI_manual.yml** 

Enables manually trigger of CI from the GitHub Web UI
- note: manually triggering GitHub Actions workflows is quite underdeveloped it seems
- the most efficient route is through a workflow yml per the below, which in turn enables to manually trigger CI from the Github Web UI. However, this manual trigger only works if the yml resides in the main branch (which it obviously doesn't at the moment), so haven't been able to test if it works